### PR TITLE
Eliminate redundant calls to `postProcess()`

### DIFF
--- a/jquery.datepick.js
+++ b/jquery.datepick.js
@@ -1271,9 +1271,6 @@ $.extend(Datepicker.prototype, {
 			showSpeed = (showSpeed == 'normal' && $.ui && $.ui.version >= '1.8' ?
 				'_default' : showSpeed);
 			var postProcess = function() {
-				if (!inst.div) {
-					return;
-				}
 				inst.div.remove();
 				inst.div = null;
 				plugin.curInst = null;
@@ -1288,10 +1285,7 @@ $.extend(Datepicker.prototype, {
 			else {
 				var hideAnim = (showAnim == 'slideDown' ? 'slideUp' :
 					(showAnim == 'fadeIn' ? 'fadeOut' : 'hide'));
-				inst.div[hideAnim]((showAnim ? showSpeed : ''), postProcess);
-			}
-			if (!showAnim) {
-				postProcess();
+				inst.div[hideAnim]((showAnim ? showSpeed : 0), postProcess);
 			}
 		}
 	},


### PR DESCRIPTION
In **Release 4.1.0**, lines [1274-1276](https://github.com/kbwood/datepick/blob/master/jquery.datepick.js#L1274) were introduced to handle redundant calls to the `postProcess()` function.  However, looking 'upstream' a little more to diagnose why redundant calls were happening in the first place, I realized that the only reason I could see for the lines **1293-1295**

```
if (!showAnim) {
  postProcess();
}
```

was to handle the case that in older versions of jQuery (for example 1.4.4) the callback would not be executed if a valid option was not given for the `jQuery.fn.hide` method's `speed` parameter.   The parameter `''` is not a valid option.

Changing the fallback parameter in line [1291](https://github.com/kbwood/datepick/blob/master/jquery.datepick.js#L1291) from `''` to `0` eliminates the necessity of lines **1293-1295**, which in turn eliminates the need for lines **1274-1276**, since redundant calls will no longer occur.

I've verified basic functionality for jQuery 1.4.4, 1.5.2, 1.6.4, 1.7.2, 1.8.2, 1.9.1.

BTW, if you'd like to make a **dev** or **working** branch for me to submit the PR to, I'd be happy to resubmit.
