### PR TITLE
fix(style): show popup in front of modal

### DIFF
--- a/flora.datepick.css
+++ b/flora.datepick.css
@@ -13,7 +13,7 @@
 	direction: rtl;
 }
 .datepick-popup {
-	z-index: 1000;
+	z-index: 1060;
 }
 .datepick-disable {
 	position: absolute;

--- a/humanity.datepick.css
+++ b/humanity.datepick.css
@@ -13,7 +13,7 @@
 	direction: rtl;
 }
 .datepick-popup {
-	z-index: 1000;
+	z-index: 1060;
 }
 .datepick-disable {
 	position: absolute;

--- a/jquery.datepick.css
+++ b/jquery.datepick.css
@@ -13,7 +13,7 @@
 	direction: rtl;
 }
 .datepick-popup {
-	z-index: 1000;
+	z-index: 1060;
 }
 .datepick-disable {
 	position: absolute;

--- a/redmond.datepick.css
+++ b/redmond.datepick.css
@@ -13,7 +13,7 @@
 	direction: rtl;
 }
 .datepick-popup {
-	z-index: 1000;
+	z-index: 1060;
 }
 .datepick-disable {
 	position: absolute;

--- a/smoothness.datepick.css
+++ b/smoothness.datepick.css
@@ -13,7 +13,7 @@
 	direction: rtl;
 }
 .datepick-popup {
-	z-index: 1000;
+	z-index: 1060;
 }
 .datepick-disable {
 	position: absolute;


### PR DESCRIPTION
Use a higher `z-index` to ensure the datepick popup is visible when used in modals (`z-index: 1050`)